### PR TITLE
WIP - try to use da.compute(*delayed)

### DIFF
--- a/ome_zarr/dask_utils.py
+++ b/ome_zarr/dask_utils.py
@@ -1,0 +1,65 @@
+from typing import Tuple
+
+import numpy as np
+import skimage.transform
+from dask import array as da
+
+# This module contributed by Andreas Eisenbarth @aeisenbarth
+# See https://github.com/toloudis/ome-zarr-py/pull/1
+
+def resize(image: da.Array, output_shape: Tuple[int, ...], *args, **kwargs) -> da.Array:
+    """
+    Wrapped copy of "skimage.transform.resize"
+
+    Resize image to match a certain size.
+
+    Args:
+        image: Input image.
+        output_shape: Size of the generated output image
+        *args: Arguments of skimage.transform.resize
+        **kwargs: Keyword arguments of skimage.transform.resize
+
+    Returns:
+        Resized image.
+    """
+    factors = np.array(output_shape) / np.array(image.shape).astype(float)
+    # Rechunk the input blocks so that the factors achieve an output blocks size of full numbers.
+    better_chunksize = tuple(
+        np.maximum(1, np.round(np.array(image.chunksize) * factors) / factors).astype(int)
+    )
+    image_prepared = image.rechunk(better_chunksize)
+    block_output_shape = tuple(np.floor(np.array(better_chunksize) * factors).astype(int))
+    # Map overlap
+    def resize_block(image_block: da.Array, block_info: dict) -> da.Array:
+        return skimage.transform.resize(image_block, block_output_shape, *args, **kwargs).astype(
+            image_block.dtype
+        )
+
+    output_slices = tuple(slice(0, d) for d in output_shape)
+    output = da.map_blocks(
+        resize_block, image_prepared, dtype=image.dtype, chunks=block_output_shape
+    )[output_slices]
+    return output.rechunk(image.chunksize).astype(image.dtype)
+
+
+def downscale_nearest(image: da.Array, factors: Tuple[int, ...]) -> da.Array:
+    """
+    Primitive downscaling by integer factors using stepped slicing.
+
+    Args:
+        image: Input image.
+        factors: Sequence of integers factors for each dimension.
+
+    Returns:
+        Resized image.
+    """
+    if not len(factors) == image.ndim:
+        raise ValueError(
+            f"Dimension mismatch: {image.ndim} image dimensions, {len(factors)} scale factors"
+        )
+    if not (all(isinstance(f, int) and 0 < f <= d for f, d in zip(factors, image.shape))):
+        raise ValueError(
+            f"All scale factors must not be greater than the dimension length: ({tuple(factors)}) <= ({tuple(image.shape)})"
+        )
+    slices = tuple(slice(None, None, factor) for factor in factors)
+    return image[slices]

--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -9,30 +9,26 @@ from collections.abc import MutableMapping
 from dataclasses import dataclass
 from typing import Callable, Iterator, List, Union
 
-import dask
+import dask.array as da
 import numpy as np
 import zarr
 from scipy.ndimage import zoom
 from skimage.transform import (
     downscale_local_mean,
     pyramid_gaussian,
-    pyramid_laplacian,
-    resize,
+    pyramid_laplacian
 )
+
+from skimage.transform import resize as skimage_resize
+from .dask_utils import resize as dask_resize
 
 from .io import parse_url
 
 LOGGER = logging.getLogger("ome_zarr.scale")
 
-ListOfArrayLike = Union[List[dask.array.Array], List[np.ndarray]]
-ArrayLike = Union[dask.array.Array, np.ndarray]
+ListOfArrayLike = Union[List[da.Array], List[np.ndarray]]
+ArrayLike = Union[da.Array, np.ndarray]
 
-
-def resize_wrapper(array, **kwargs):
-    print("resize_wrapper...", array.shape, kwargs)
-    rsp = resize(array, **kwargs)
-    print("resize_wrapper rsp", rsp.shape)
-    return rsp
 
 @dataclass
 class Scaler:
@@ -139,46 +135,29 @@ class Scaler:
                 path = "base"
             else:
                 path = "%s" % i
-                grp.create_dataset(path, data=pyramid[i])
+                grp.create_dataset(path, data=dataset)
             series.append({"path": path})
         return grp
 
-    def nearest(self, base: ArrayLike) -> ListOfArrayLike:
+    def nearest(self, image: ArrayLike) -> ArrayLike:
         """
         Downsample using :func:`skimage.transform.resize`.
-
-        The :const:`cvs2.INTER_NEAREST` interpolation method is used.
         """
-        return self._by_plane(base, self.__nearest)
-
-    def __nearest(self, plane: ArrayLike, sizeY: int, sizeX: int) -> ArrayLike:
-        """Apply the 2-dimensional transformation."""
-        if isinstance(plane, dask.array.Array):
-            # print("downscale_nearest...", plane.shape, plane.dtype)
-            # return downscale_nearest(plane, factors=(self.downscale, self.downscale))
-            print("resize...", self.downscale, sizeX, sizeY)
-            outsize = (np.ceil(np.array([sizeY, sizeX]) / self.downscale)).astype(int)
-            print("outsize", outsize)
-            resized = dask.array.map_blocks(
-                resize_wrapper,
-                plane,
-                output_shape=(outsize[0], outsize[1]),
-                order=0,
-                preserve_range=True,
-                anti_aliasing=False,
-                dtype=plane.dtype,
-                chunks=(outsize[0], outsize[1]),
-            )
-            print("__nearest resized", resized.shape)
-            return resized
+        if isinstance(image, da.Array):
+            _resize = lambda image, out_shape, **kwargs: dask_resize(image, out_shape)
         else:
-            return resize(
-                plane,
-                output_shape=(sizeY // self.downscale, sizeX // self.downscale),
-                order=0,
-                preserve_range=True,
-                anti_aliasing=False,
-            ).astype(plane.dtype)
+            _resize = skimage_resize
+
+        # only down-sample in X and Y dimensions for now...
+        out_shape = list(image.shape)
+        out_shape[-1] = np.ceil(float(image.shape[-1]) / self.downscale)
+        out_shape[-2] = np.ceil(float(image.shape[-2]) / self.downscale)
+
+        dtype = image.dtype
+        image = _resize(
+            image.astype(float), out_shape, order=1, mode="reflect", anti_aliasing=False
+        )
+        return image.astype(dtype)
 
     def gaussian(self, base: np.ndarray) -> List[np.ndarray]:
         """Downsample using :func:`skimage.transform.pyramid_gaussian`."""
@@ -220,58 +199,3 @@ class Scaler:
             rv.append(zoom(base, self.downscale**i))
             print(rv[-1].shape)
         return list(reversed(rv))
-
-    #
-    # Helpers
-    #
-
-    def _by_plane(
-        self,
-        base: ArrayLike,
-        func: Callable[[ArrayLike, int, int], ArrayLike],
-    ) -> ListOfArrayLike:
-        """Loop over 3 of the 5 dimensions and apply the func transform."""
-
-        # start by putting the original data as the first level
-        rv = [base]
-        for i in range(self.max_layer):
-            stack_to_scale = rv[-1]
-            shape_5d = (*(1,) * (5 - stack_to_scale.ndim), *stack_to_scale.shape)
-            T, C, Z, Y, X = shape_5d
-            print("_by_plane stack_to_scale.shape", stack_to_scale.shape)
-            print("_by_plane prev shape_5d", shape_5d)
-            print("_by_plane, Y, X", Y, X)
-
-            # If our data is already 2D, simply resize and add to pyramid
-            if stack_to_scale.ndim == 2:
-                rv.append(func(stack_to_scale, Y, X))
-                continue
-
-            # stack_dims is any dims over 2D
-            stack_dims = stack_to_scale.ndim - 2
-            new_stack = None
-            for t in range(T):
-                for c in range(C):
-                    for z in range(Z):
-                        dims_to_slice = (t, c, z)[-stack_dims:]
-                        # slice nd down to 2D
-                        plane = stack_to_scale[(dims_to_slice)][:]
-                        out = func(plane, Y, X)
-                        # first iteration of loop creates the new nd stack
-                        if new_stack is None:
-                            zct_dims = shape_5d[:-2]
-                            shape_dims = zct_dims[-stack_dims:]
-                            if isinstance(out, dask.array.Array):
-                                new_stack = dask.array.zeros(
-                                    (*shape_dims, out.shape[0], out.shape[1]),
-                                    dtype=base.dtype,
-                                )
-                            else:
-                                new_stack = np.zeros(
-                                    (*shape_dims, out.shape[0], out.shape[1]),
-                                    dtype=base.dtype,
-                                )
-                        # insert resized plane into the stack at correct indices
-                        new_stack[(dims_to_slice)] = out
-            rv.append(new_stack)
-        return rv

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -259,8 +259,6 @@ Please use the 'storage_options' argument instead."""
             chunks_opt = _retuple(chunks_opt, image.shape)
             image = da.array(image).rechunk(chunks=chunks)
             options["chunks"] = chunks_opt
-        else:
-            chunks_opt = (1, 256, 256)
         LOGGER.debug(f"chunks_opt: {chunks_opt}")
 
         shapes.append(image.shape)


### PR DESCRIPTION
See discussion at https://github.com/ome/ome-zarr-py/pull/192

The first commit here was a light-weight change to replicate the behaviour in `ngff-writer` (without changing the ome-zarr-py api), calling `da.compute(*delayed)` with `compute=False` when writing each plane to zarr.
This is certainly faster, but is breaks the `map_blocks(resize...)` logic, resulting in a pyramid that gets bigger instead of smaller!? (hence all the print statements).

Might need to replicate more closely what `ngff-writer` is doing, with `write_multiscales(array)` handling the resizing AND writing to zarr, instead of the resizing happening before and passing in a pyramid.

cc @toloudis @aeisenbarth