### PR TITLE
Dask poc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,19 @@ It can be built locally with:
     pip install spinx
     sphinx-build -b html docs/source/ docs/build/html
 
+Tests
+-----
+
+Tests can be run locally via `tox` with:
+
+    $ pip install tox
+    $ tox
+
+To enable pre-commit code validation:
+
+    $ pip install pre-commit
+    $ pre-commit install
+
 Release process
 ---------------
 

--- a/ome_zarr/dask_utils.py
+++ b/ome_zarr/dask_utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Any, Tuple
 
 import numpy as np
 import skimage.transform
@@ -9,7 +9,7 @@ from dask import array as da
 
 
 def resize(
-    image: da.Array, output_shape: Tuple[int, ...], *args: int, **kwargs: str
+    image: da.Array, output_shape: Tuple[int, ...], *args: Any, **kwargs: Any
 ) -> da.Array:
     r"""
     Wrapped copy of "skimage.transform.resize"

--- a/ome_zarr/dask_utils.py
+++ b/ome_zarr/dask_utils.py
@@ -13,9 +13,7 @@ def resize(
 ) -> da.Array:
     r"""
     Wrapped copy of "skimage.transform.resize"
-
     Resize image to match a certain size.
-
     :type image: :class:`dask.array`
     :param image: The dask array to resize
     :type output_shape: tuple
@@ -55,7 +53,6 @@ def resize(
 def downscale_nearest(image: da.Array, factors: Tuple[int, ...]) -> da.Array:
     """
     Primitive downscaling by integer factors using stepped slicing.
-
     :type image: :class:`dask.array`
     :param image: The dask array to resize
     :type factors: tuple

--- a/ome_zarr/dask_utils.py
+++ b/ome_zarr/dask_utils.py
@@ -8,23 +8,27 @@ from dask import array as da
 # See https://github.com/toloudis/ome-zarr-py/pull/1
 
 
-def resize(image: da.Array, output_shape: Tuple[int, ...], *args, **kwargs) -> da.Array:
-    """
+def resize(
+    image: da.Array, output_shape: Tuple[int, ...], *args: int, **kwargs: str
+) -> da.Array:
+    r"""
     Wrapped copy of "skimage.transform.resize"
 
     Resize image to match a certain size.
 
-    Args:
-        image: Input image.
-        output_shape: Size of the generated output image
-        *args: Arguments of skimage.transform.resize
-        **kwargs: Keyword arguments of skimage.transform.resize
-
-    Returns:
-        Resized image.
+    :type image: :class:`dask.array`
+    :param image: The dask array to resize
+    :type output_shape: tuple
+    :param output_shape: The shape of the resize array
+    :type \*args: list
+    :param \*args: Arguments of skimage.transform.resize
+    :type \*\*kwargs: dict
+    :param \*\*kwargs: Keyword arguments of skimage.transform.resize
+    :return: Resized image.
     """
     factors = np.array(output_shape) / np.array(image.shape).astype(float)
-    # Rechunk the input blocks so that the factors achieve an output blocks size of full numbers.
+    # Rechunk the input blocks so that the factors achieve an output
+    # blocks size of full numbers.
     better_chunksize = tuple(
         np.maximum(1, np.round(np.array(image.chunksize) * factors) / factors).astype(
             int
@@ -34,6 +38,7 @@ def resize(image: da.Array, output_shape: Tuple[int, ...], *args, **kwargs) -> d
     block_output_shape = tuple(
         np.floor(np.array(better_chunksize) * factors).astype(int)
     )
+
     # Map overlap
     def resize_block(image_block: da.Array, block_info: dict) -> da.Array:
         return skimage.transform.resize(
@@ -51,22 +56,23 @@ def downscale_nearest(image: da.Array, factors: Tuple[int, ...]) -> da.Array:
     """
     Primitive downscaling by integer factors using stepped slicing.
 
-    Args:
-        image: Input image.
-        factors: Sequence of integers factors for each dimension.
-
-    Returns:
-        Resized image.
+    :type image: :class:`dask.array`
+    :param image: The dask array to resize
+    :type factors: tuple
+    :param factors: Sequence of integers factors for each dimension.
+    :return: Resized image.
     """
     if not len(factors) == image.ndim:
         raise ValueError(
-            f"Dimension mismatch: {image.ndim} image dimensions, {len(factors)} scale factors"
+            f"Dimension mismatch: {image.ndim} image dimensions, "
+            f"{len(factors)} scale factors"
         )
     if not (
         all(isinstance(f, int) and 0 < f <= d for f, d in zip(factors, image.shape))
     ):
         raise ValueError(
-            f"All scale factors must not be greater than the dimension length: ({tuple(factors)}) <= ({tuple(image.shape)})"
+            f"All scale factors must not be greater than the dimension length: "
+            f"({tuple(factors)}) <= ({tuple(image.shape)})"
         )
     slices = tuple(slice(None, None, factor) for factor in factors)
     return image[slices]

--- a/ome_zarr/data.py
+++ b/ome_zarr/data.py
@@ -14,7 +14,7 @@ from skimage.segmentation import clear_border
 from .format import CurrentFormat, Format
 from .io import parse_url
 from .scale import Scaler
-from .writer import write_image
+from .writer import write_multiscale
 
 CHANNEL_DIMENSION = 1
 
@@ -45,14 +45,14 @@ def astronaut() -> Tuple[List, List]:
     blue = astro[:, :, 2]
     astro = np.array([red, green, blue])
     pixels = np.tile(astro, (1, 2, 2))
-    pyramid = scaler.nearest(pixels)
+    pyramid = scaler.gaussian(pixels)
 
     shape = list(pyramid[0].shape)
     c, y, x = shape
     label = np.zeros((y, x), dtype=np.int8)
     make_circle(100, 100, 1, label[200:300, 200:300])
     make_circle(150, 150, 2, label[250:400, 250:400])
-    labels = scaler.nearest(label)
+    labels = scaler.gaussian(label)
 
     return pyramid, labels
 
@@ -136,7 +136,7 @@ def create_zarr(
                 chunks[zct] = 1
 
     storage_options = dict(chunks=tuple(chunks))
-    write_image(pyramid, grp, axes=axes, storage_options=storage_options)
+    write_multiscale(pyramid, grp, axes=axes, storage_options=storage_options)
 
     if size_c == 1:
         image_data = {
@@ -178,7 +178,7 @@ def create_zarr(
         if axes is not None:
             # remove channel axis for masks
             axes = axes.replace("c", "")
-        write_image(labels, label_grp, axes=axes)
+        write_multiscale(labels, label_grp, axes=axes)
 
         colors = []
         properties = []

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -490,7 +490,7 @@ class Plate(Spec):
         well_node = Node(well_zarr, node)
         well_spec: Optional[Well] = well_node.first(Well)
         if well_spec is None:
-            raise Exception("could not find first well")
+            raise Exception("Could not find first well")
         self.numpy_type = well_spec.numpy_type
 
         LOGGER.debug(f"img_pyramid_shapes: {well_spec.img_pyramid_shapes}")

--- a/ome_zarr/scale.py
+++ b/ome_zarr/scale.py
@@ -7,7 +7,7 @@ import logging
 import os
 from collections.abc import MutableMapping
 from dataclasses import dataclass
-from typing import Callable, Iterator, List, Union
+from typing import Any, Iterator, List, Tuple, Union
 
 import dask.array as da
 import numpy as np
@@ -139,14 +139,18 @@ class Scaler:
         Downsample using :func:`skimage.transform.resize`.
         """
         if isinstance(image, da.Array):
-            _resize = lambda image, out_shape, **kwargs: dask_resize(image, out_shape)
+
+            def _resize(image: ArrayLike, out_shape: Tuple, **kwargs: Any) -> ArrayLike:
+                return dask_resize(image, out_shape, **kwargs)
+
         else:
             _resize = skimage_resize
 
         # only down-sample in X and Y dimensions for now...
-        out_shape = list(image.shape)
-        out_shape[-1] = np.ceil(float(image.shape[-1]) / self.downscale)
-        out_shape[-2] = np.ceil(float(image.shape[-2]) / self.downscale)
+        new_shape = list(image.shape)
+        new_shape[-1] = np.ceil(float(image.shape[-1]) / self.downscale)
+        new_shape[-2] = np.ceil(float(image.shape[-2]) / self.downscale)
+        out_shape = tuple(new_shape)
 
         dtype = image.dtype
         image = _resize(

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -170,10 +170,9 @@ def _validate_plate_wells(
     return validated_wells
 
 
-def write_image(
-    image: np.ndarray,
+def write_multiscale(
+    pyramid: List,
     group: zarr.Group,
-    scaler: Scaler = Scaler(),
     chunks: Union[Tuple[Any, ...], int] = None,
     fmt: Format = CurrentFormat(),
     axes: Union[str, List[str], List[Dict[str, str]]] = None,
@@ -218,7 +217,7 @@ def write_image(
         option.
     """
 
-    dims = len(image.shape)
+    dims = len(pyramid[0].shape)
     axes = _get_valid_axes(dims, axes, fmt)
 
     if chunks is not None:
@@ -227,13 +226,7 @@ Please use the 'storage_options' argument instead."""
         warnings.warn(msg, DeprecationWarning)
 
     datasets: List[dict] = []
-    delayed = []
-
-    # for path, data in enumerate(pyramid):
-    max_layer: int = scaler.max_layer  # 3
-    shapes = []
-    for path in range(0, max_layer + 1):
-        LOGGER.debug(f"write_image path: {path}")
+    for path, data in enumerate(pyramid):
         options = {}
         if storage_options:
             options = (
@@ -241,11 +234,6 @@ Please use the 'storage_options' argument instead."""
                 if not isinstance(storage_options, list)
                 else storage_options[path]
             )
-
-        # don't downsample top level of pyramid
-        if str(path) != "0":
-            image = scaler.nearest(image)
-
         # ensure that the chunk dimensions match the image dimensions
         # (which might have been changed for versions 0.1 or 0.2)
         # if chunks are explicitly set in the storage options
@@ -253,39 +241,17 @@ Please use the 'storage_options' argument instead."""
         # switch to this code in 0.5
         # chunks_opt = options.pop("chunks", None)
         if chunks_opt is not None:
-            chunks_opt = _retuple(chunks_opt, image.shape)
-            image = da.array(image).rechunk(chunks=chunks_opt)
-            options["chunks"] = chunks_opt
-        LOGGER.debug(f"chunks_opt: {chunks_opt}")
-
-        shapes.append(image.shape)
-        if isinstance(image, da.Array):
-            LOGGER.debug(
-                f"write dask.array to_zarr shape:{image.shape}, dtype {image.dtype}"
-            )
-            delayed.append(
-                da.to_zarr(
-                    array_key=path,
-                    arr=image,
-                    url=group.store,
-                    component=str(Path(group.path, str(path))),
-                    storage_options=options,
-                    compute=False,
-                )
-            )
-        else:
-            group.create_dataset(str(path), data=image, chunks=chunks_opt, **options)
+            chunks_opt = _retuple(chunks_opt, data.shape)
+        group.create_dataset(str(path), data=data, chunks=chunks_opt, **options)
         datasets.append({"path": str(path)})
 
-    da.compute(*delayed)
-
     if coordinate_transformations is None:
-        # shapes = [data.shape for data in delayed]
+        shapes = [data.shape for data in pyramid]
         coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
 
     # we validate again later, but this catches length mismatch before zip(datasets...)
     fmt.validate_coordinate_transformations(
-        dims, len(delayed), coordinate_transformations
+        dims, len(pyramid), coordinate_transformations
     )
     if coordinate_transformations is not None:
         for dataset, transform in zip(datasets, coordinate_transformations):
@@ -419,31 +385,32 @@ def write_well_metadata(
     }
     group.attrs["well"] = well
 
-    # def write_image(
-    #     image: np.ndarray,
-    #     group: zarr.Group,
-    #     scaler: Scaler = Scaler(),
-    #     chunks: Union[Tuple[Any, ...], int] = None,
-    #     fmt: Format = CurrentFormat(),
-    #     axes: Union[str, List[str], List[Dict[str, str]]] = None,
-    #     coordinate_transformations: List[List[Dict[str, Any]]] = None,
-    #     storage_options: Union[JSONDict, List[JSONDict]] = None,
-    #     **metadata: Union[str, JSONDict, List[JSONDict]],
-    # ) -> None:
+
+def write_image(
+    image: np.ndarray,
+    group: zarr.Group,
+    scaler: Scaler = Scaler(),
+    chunks: Union[Tuple[Any, ...], int] = None,
+    fmt: Format = CurrentFormat(),
+    axes: Union[str, List[str], List[Dict[str, str]]] = None,
+    coordinate_transformations: List[List[Dict[str, Any]]] = None,
+    storage_options: Union[JSONDict, List[JSONDict]] = None,
+    **metadata: Union[str, JSONDict, List[JSONDict]],
+) -> None:
     """Writes an image to the zarr store according to ome-zarr specification
 
     :type image: :class:`numpy.ndarray`
     :param image:
-      The image data to save. A downsampling of the data will be computed
-      if the scaler argument is non-None.
-      Image array MUST be up to 5-dimensional with dimensions
-      ordered (t, c, z, y, x)
+        The image data to save. A downsampling of the data will be computed
+        if the scaler argument is non-None.
+        Image array MUST be up to 5-dimensional with dimensions
+        ordered (t, c, z, y, x)
     :type group: :class:`zarr.hierarchy.Group`
     :param group: The group within the zarr store to write the metadata in.
     :type scaler: :class:`ome_zarr.scale.Scaler`
     :param scaler:
-      Scaler implementation for downsampling the image argument. If None,
-      no downsampling will be performed.
+        Scaler implementation for downsampling the image argument. If None,
+        no downsampling will be performed.
     :type chunks: int or tuple of ints, optional
     :param chunks:
         The size of the saved chunks to store the image.
@@ -453,16 +420,16 @@ def write_well_metadata(
             Use :attr:`storage_options` instead.
     :type fmt: :class:`ome_zarr.format.Format`, optional
     :param fmt:
-      The format of the ome_zarr data which should be used.
-      Defaults to the most current.
+        The format of the ome_zarr data which should be used.
+        Defaults to the most current.
     :type axes: list of str or list of dicts, optional
     :param axes:
-      The names of the axes. e.g. ["t", "c", "z", "y", "x"].
-      Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
+        The names of the axes. e.g. ["t", "c", "z", "y", "x"].
+        Ignored for versions 0.1 and 0.2. Required for version 0.3 or greater.
     :type coordinate_transformations: list of dict
     :param coordinate_transformations:
-      For each resolution, we have a List of transformation Dicts (not validated).
-      Each list of dicts are added to each datasets in order.
+        For each resolution, we have a List of transformation Dicts (not validated).
+        Each list of dicts are added to each datasets in order.
     :type storage_options: dict or list of dict, optional
     :param storage_options:
         Options to be passed on to the storage backend.
@@ -470,19 +437,80 @@ def write_well_metadata(
         One can provide different chunk size for each level of a pyramid using this
         option.
     """
-    # scaler.max_layer = 2
-    # mip, axes = _create_mip(image, fmt, scaler, axes)
-    # write_multiscale(
-    #     image,
-    #     group,
-    #     scaler,
-    #     chunks=chunks,
-    #     fmt=fmt,
-    #     axes=axes,
-    #     coordinate_transformations=coordinate_transformations,
-    #     storage_options=storage_options,
-    #     **metadata,
-    # )
+    dims = len(image.shape)
+    axes = _get_valid_axes(dims, axes, fmt)
+
+    if chunks is not None:
+        msg = """The 'chunks' argument is deprecated and will be removed in version 0.5.
+Please use the 'storage_options' argument instead."""
+        warnings.warn(msg, DeprecationWarning)
+
+    datasets: List[dict] = []
+    delayed = []
+
+    # for path, data in enumerate(pyramid):
+    max_layer: int = scaler.max_layer  # 3
+    shapes = []
+    for path in range(0, max_layer + 1):
+        LOGGER.debug(f"write_image path: {path}")
+        options = {}
+        if storage_options:
+            options = (
+                storage_options
+                if not isinstance(storage_options, list)
+                else storage_options[path]
+            )
+
+        # don't downsample top level of pyramid
+        if str(path) != "0":
+            image = scaler.nearest(image)
+
+        # ensure that the chunk dimensions match the image dimensions
+        # (which might have been changed for versions 0.1 or 0.2)
+        # if chunks are explicitly set in the storage options
+        chunks_opt = options.pop("chunks", chunks)
+        # switch to this code in 0.5
+        # chunks_opt = options.pop("chunks", None)
+        if chunks_opt is not None:
+            chunks_opt = _retuple(chunks_opt, image.shape)
+            image = da.array(image).rechunk(chunks=chunks_opt)
+            options["chunks"] = chunks_opt
+        LOGGER.debug(f"chunks_opt: {chunks_opt}")
+
+        shapes.append(image.shape)
+        if isinstance(image, da.Array):
+            LOGGER.debug(
+                f"write dask.array to_zarr shape:{image.shape}, dtype {image.dtype}"
+            )
+            delayed.append(
+                da.to_zarr(
+                    array_key=path,
+                    arr=image,
+                    url=group.store,
+                    component=str(Path(group.path, str(path))),
+                    storage_options=options,
+                    compute=False,
+                )
+            )
+        else:
+            group.create_dataset(str(path), data=image, chunks=chunks_opt, **options)
+        datasets.append({"path": str(path)})
+
+    da.compute(*delayed)
+
+    if coordinate_transformations is None:
+        # shapes = [data.shape for data in delayed]
+        coordinate_transformations = fmt.generate_coordinate_transformations(shapes)
+
+    # we validate again later, but this catches length mismatch before zip(datasets...)
+    fmt.validate_coordinate_transformations(
+        dims, len(delayed), coordinate_transformations
+    )
+    if coordinate_transformations is not None:
+        for dataset, transform in zip(datasets, coordinate_transformations):
+            dataset["coordinateTransformations"] = transform
+
+    write_multiscales_metadata(group, datasets, fmt, axes, **metadata)
 
 
 def write_label_metadata(
@@ -583,18 +611,18 @@ def write_multiscale_labels(
     :param label_metadata:
       Image label metadata. See :meth:`write_label_metadata` for details
     """
-    # sub_group = group.require_group(f"labels/{name}")
-    # write_image(
-    #     image=pyramid,
-    #     group=sub_group,
-    #     scaler=Scaler(),
-    #     chunks=chunks,
-    #     fmt=fmt,
-    #     axes=axes,
-    #     coordinate_transformations=coordinate_transformations,
-    #     storage_options=storage_options,
-    #     **metadata,
-    # )
+    sub_group = group.require_group(f"labels/{name}")
+    write_image(
+        image=pyramid,
+        group=sub_group,
+        scaler=Scaler(),
+        chunks=chunks,
+        fmt=fmt,
+        axes=axes,
+        coordinate_transformations=coordinate_transformations,
+        storage_options=storage_options,
+        **metadata,
+    )
     write_label_metadata(
         group["labels"], name, **({} if label_metadata is None else label_metadata)
     )

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -583,7 +583,7 @@ def write_multiscale_labels(
     :param label_metadata:
       Image label metadata. See :meth:`write_label_metadata` for details
     """
-    sub_group = group.require_group(f"labels/{name}")
+    # sub_group = group.require_group(f"labels/{name}")
     # write_image(
     #     image=pyramid,
     #     group=sub_group,

--- a/ome_zarr/writer.py
+++ b/ome_zarr/writer.py
@@ -504,7 +504,7 @@ Please use the 'storage_options' argument instead."""
 
     # we validate again later, but this catches length mismatch before zip(datasets...)
     fmt.validate_coordinate_transformations(
-        dims, len(delayed), coordinate_transformations
+        dims, len(datasets), coordinate_transformations
     )
     if coordinate_transformations is not None:
         for dataset, transform in zip(datasets, coordinate_transformations):


### PR DESCRIPTION
mypy and flake8 fixes.

I wasn't sure how to handle `*args` and `**kwargs` in mypy. See https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values.
The types of extra `resize` args (see https://scikit-image.org/docs/dev/api/skimage.transform.html#resize) are various, so I added arbitrary types to make `mypy` happy, but this might break someone else's mypy??

I also had to escape `\*\*kwargs` in the docstring as described https://github.com/peterjc/flake8-rst-docstrings/issues/18

cc @toloudis @joshmoore